### PR TITLE
Create Nix flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,26 @@
+name: Nix
+
+on: push
+
+jobs:
+  check:
+    name: Check flake
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Nix
+        uses: cachix/install-nix-action@v13
+        env:
+          NIX_VERSION: nix-2.4pre20210604_8e6ee1b
+        with:
+          install_url: https://github.com/numtide/nix-unstable-installer/releases/download/${{ env.NIX_VERSION }}/install
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Run flake checks
+        run: nix flake check -v --show-trace

--- a/README.md
+++ b/README.md
@@ -3,7 +3,16 @@ The Discord Companion and RPG Bot
 
 ## Launch
 
+Install the Nix package manager by running this command:
 ```sh
-python -m pip install -e .
-QUABBOT_TOKEN="xxxxx" quabbot
+curl -L https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210604_8e6ee1b/install | sh
+```
+Add this to `~/.config/nix/nix.conf`, creating the file if it doesn't exist:
+```ini
+experimental-features = nix-command flakes
+```
+
+Then you can use this command to run Quabbot:
+```sh
+QUABBOT_TOKEN="xxxxx" nix run
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1626852498,
+        "narHash": "sha256-lOXUJvi0FJUXHTVSiC5qsMRtEUgqM4mGZpMESLuGhmo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16105403bdd843540cbef9c63fc0f16c1c6eaa70",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        inherit (pkgs) fetchFromGitHub;
+        inherit (pkgs.python3Packages)
+          buildPythonPackage buildPythonApplication fetchPypi aiohttp discordpy;
+
+        discord-py-slash-command = buildPythonPackage rec {
+          pname = "discord-py-slash-command";
+          version = "2.3.1";
+          src = fetchPypi {
+            inherit pname version;
+            sha256 = "R2+lSV3WIZDg02F0Qbqn5ef6Mb/v73+I945CgWZsDUE=";
+          };
+          propagatedBuildInputs = [ aiohttp discordpy ];
+        };
+
+        typish = buildPythonPackage rec {
+          pname = "typish";
+          version = "1.9.2";
+          src = fetchFromGitHub {
+            owner = "ramonhagenaars";
+            repo = "typish";
+            rev = "v${version}";
+            sha256 = "prgY43NS9QmBW8TcRUaW+rc7NdsNTWqWxgBSL39Wk30=";
+          };
+          doCheck = false;
+        };
+
+        jsons = buildPythonPackage rec {
+          pname = "jsons";
+          version = "1.5.0";
+          src = fetchFromGitHub {
+            owner = "ramonhagenaars";
+            repo = "jsons";
+            rev = "v${version}";
+            sha256 = "V8iZPPiMEcjj0RzNILNFtSROjDVfiQDmh6G3d2XSOCY=";
+          };
+          propagatedBuildInputs = [ typish ];
+          doCheck = false;
+        };
+
+      in rec {
+        packages.quabbot = buildPythonApplication rec {
+          name = "quabbot";
+          src = ./.;
+          propagatedBuildInputs = [ discord-py-slash-command discordpy jsons ];
+        };
+        defaultPackage = packages.quabbot;
+
+        apps.quabbot = utils.lib.mkApp { drv = packages.quabbot; };
+        defaultApp = apps.quabbot;
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -57,5 +57,7 @@
 
         apps.quabbot = utils.lib.mkApp { drv = packages.quabbot; };
         defaultApp = apps.quabbot;
+
+        checks = packages;
       });
 }


### PR DESCRIPTION
Nix packages are fully reproducible, so if Quabbot runs on one machine when installed using Nix, it is guaranteed to run everywhere. Therefore this fixes #24.

---

The Nix package manager can be installed on any Linux distribution by running:
```sh
curl -L https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210604_8e6ee1b/install | sh
```
Add this to `~/.config/nix/nix.conf`:
```ini
experimental-features = nix-command flakes
```
Then simply use `nix run` to start Quabbot. `pip install` is no longer needed.