### PR TITLE
Add flake-compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,29 @@ The Discord Companion and RPG Bot
 
 ## Launch
 
-Install the Nix package manager by running this command:
-```sh
-curl -L https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210604_8e6ee1b/install | sh
-```
-Add this to `~/.config/nix/nix.conf`, creating the file if it doesn't exist:
+The [Nix package manager](https://nixos.org/)
+can be installed on most Linux distributions.
+
+### Nix Unstable
+
+Add this to `/etc/nix/nix.conf` or `~/.config/nix/nix.conf`,
+creating the file if it doesn't exist:
+
 ```ini
 experimental-features = nix-command flakes
 ```
 
-Then you can use this command to run Quabbot:
+Then, this command will start Quabbot:
+
 ```sh
 QUABBOT_TOKEN="xxxxx" nix run
+```
+
+### Nix Stable
+
+Run the following commands:
+
+```sh
+nix build
+QUABBOT_TOKEN="xxxxx" ./result/bin/quabbot
 ```

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    inherit (lock.nodes.flake-compat.locked) rev narHash;
+  in fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  }
+) {
+  src =  ./.;
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1606424373,
+        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1626852498,
@@ -18,6 +34,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,13 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, utils }:
+  outputs = { nixpkgs, utils, ... }:
     utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};


### PR DESCRIPTION
This allows Quabbot to be built on the stable version of Nix.